### PR TITLE
utilize requests error rate threshold

### DIFF
--- a/src/ecs.ts
+++ b/src/ecs.ts
@@ -83,7 +83,7 @@ export class WatchEcsService extends cdk.Construct {
 
     const { requestsMetric, requestsAlarm } = this.createRequestsMonitor(props.requestsThreshold);
     const { http2xxMetric, http3xxMetric, http4xxMetric, http5xxMetric } = this.createHttpRequestsMetrics();
-    const { requestsErrorRateMetric, requestsErrorRateAlarm } = this.requestsErrorRate(http4xxMetric, http5xxMetric, requestsMetric);
+    const { requestsErrorRateMetric, requestsErrorRateAlarm } = this.requestsErrorRate(http4xxMetric, http5xxMetric, requestsMetric, props.requestsErrorRateThreshold );
 
 
     this.watchful.addWidgets(

--- a/src/ecs.ts
+++ b/src/ecs.ts
@@ -83,7 +83,8 @@ export class WatchEcsService extends cdk.Construct {
 
     const { requestsMetric, requestsAlarm } = this.createRequestsMonitor(props.requestsThreshold);
     const { http2xxMetric, http3xxMetric, http4xxMetric, http5xxMetric } = this.createHttpRequestsMetrics();
-    const { requestsErrorRateMetric, requestsErrorRateAlarm } = this.requestsErrorRate(http4xxMetric, http5xxMetric, requestsMetric, props.requestsErrorRateThreshold );
+    const { requestsErrorRateMetric, requestsErrorRateAlarm } = this.requestsErrorRate(
+      http4xxMetric, http5xxMetric, requestsMetric, props.requestsErrorRateThreshold);
 
 
     this.watchful.addWidgets(


### PR DESCRIPTION
- need to pass props.requestsErrorRateThreshold to helper function
- lint 

this will support a non-zero alarm value for http requests error rate as shown

![image](https://user-images.githubusercontent.com/72764546/122961692-7c7b8b00-d339-11eb-920c-b74c7771794f.png)

