### PR TITLE
add alarms to lambda invocations

### DIFF
--- a/API.md
+++ b/API.md
@@ -439,6 +439,25 @@ new WatchLambdaFunction(scope: Construct, id: string, props: WatchLambdaFunction
 
 ---
 
+#### Methods <a name="Methods"></a>
+
+##### `createInvocationsMonitor` <a name="@myhelix/cdk-watchful.WatchLambdaFunction.createInvocationsMonitor"></a>
+
+```typescript
+public createInvocationsMonitor(invocationsEnableAlerts?: boolean, invocationsThreshold?: Duration)
+```
+
+###### `invocationsEnableAlerts`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunction.parameter.invocationsEnableAlerts"></a>
+
+- *Type:* `boolean`
+
+---
+
+###### `invocationsThreshold`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunction.parameter.invocationsThreshold"></a>
+
+- *Type:* [`@aws-cdk/core.Duration`](#@aws-cdk/core.Duration)
+
+---
 
 
 
@@ -1054,6 +1073,23 @@ If there are more errors than that, an alarm will trigger.
 
 ---
 
+##### `invocationsEnableAlerts`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunctionOptions.property.invocationsEnableAlerts"></a>
+
+- *Type:* `boolean`
+- *Default:* false
+
+Flag to enable alerting on invocationsMetric.
+
+---
+
+##### `invocationsThreshold`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunctionOptions.property.invocationsThreshold"></a>
+
+- *Type:* [`@aws-cdk/core.Duration`](#@aws-cdk/core.Duration)
+
+Threshold for alerting invocations.
+
+---
+
 ##### `throttlesPerMinuteThreshold`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunctionOptions.property.throttlesPerMinuteThreshold"></a>
 
 - *Type:* `number`
@@ -1114,6 +1150,23 @@ Flag to disable alerting on errors.
 Number of allowed errors per minute.
 
 If there are more errors than that, an alarm will trigger.
+
+---
+
+##### `invocationsEnableAlerts`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunctionProps.property.invocationsEnableAlerts"></a>
+
+- *Type:* `boolean`
+- *Default:* false
+
+Flag to enable alerting on invocationsMetric.
+
+---
+
+##### `invocationsThreshold`<sup>Optional</sup> <a name="@myhelix/cdk-watchful.WatchLambdaFunctionProps.property.invocationsThreshold"></a>
+
+- *Type:* [`@aws-cdk/core.Duration`](#@aws-cdk/core.Duration)
+
+Threshold for alerting invocations.
 
 ---
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,6 +1,6 @@
 import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
 import * as lambda from '@aws-cdk/aws-lambda';
-import { Construct } from '@aws-cdk/core';
+import { Construct, Duration } from '@aws-cdk/core';
 import { IWatchful } from './api';
 
 const DEFAULT_DURATION_THRESHOLD_PERCENT = 80;
@@ -19,6 +19,18 @@ export interface WatchLambdaFunctionOptions {
    * @default 0
    */
   readonly errorsPerMinuteThreshold?: number;
+
+  /**
+   * Flag to enable alerting on invocationsMetric
+   *
+    @default false
+   */
+  readonly invocationsEnableAlerts?: boolean;
+
+  /**
+   * Threshold for alerting invocations
+   */
+  readonly invocationsThreshold?: Duration;
 
   /**
    * Number of allowed throttles per minute.
@@ -58,6 +70,14 @@ export class WatchLambdaFunction extends Construct {
 
   private readonly watchful: IWatchful;
   private readonly fn: lambda.IFunction;
+  private invocationsMetric!: cloudwatch.Metric;
+  private invocationsAlarm: cloudwatch.Alarm | undefined;
+  private errorsMetric!: cloudwatch.Metric;
+  private errorsAlarm: cloudwatch.Alarm | undefined;
+  private throttlesMetric!: cloudwatch.Metric;
+  private throttlesAlarm!: cloudwatch.Alarm;
+  private durationMetric!: cloudwatch.Metric;
+  private durationAlarm!: cloudwatch.Alarm;
 
   constructor(scope: Construct, id: string, props: WatchLambdaFunctionProps) {
     super(scope, id);
@@ -76,88 +96,111 @@ export class WatchLambdaFunction extends Construct {
       ],
     });
 
-    const { errorsMetric, errorsAlarm } = this.createErrorsMonitor(props.errorsDisableAlerts, props.errorsPerMinuteThreshold);
-    const { throttlesMetric, throttlesAlarm } = this.createThrottlesMonitor(props.throttlesPerMinuteThreshold);
-    const { durationMetric, durationAlarm } = this.createDurationMonitor(timeoutSec!, props.durationThresholdPercent);
-    const invocationsMetric = this.fn.metricInvocations();
+    this.createInvocationsMonitor(props.invocationsEnableAlerts, props.invocationsThreshold);
+    this.createErrorsMonitor(props.errorsDisableAlerts, props.errorsPerMinuteThreshold);
+    this.createThrottlesMonitor(props.throttlesPerMinuteThreshold);
+    this.createDurationMonitor(timeoutSec!, props.durationThresholdPercent);
+
+    let invocationWidget: cloudwatch.IWidget;
+    if (!props.invocationsEnableAlerts) {
+      invocationWidget = new cloudwatch.GraphWidget({
+        title: `Invocations/${this.invocationsMetric.period.toMinutes()}min`,
+        width: 6,
+        left: [this.invocationsMetric],
+      });
+    } else {
+      invocationWidget = new cloudwatch.AlarmWidget({
+        title: `Invocations/${this.invocationsMetric.period.toMinutes()}min`,
+        alarm: this.invocationsAlarm!,
+        width: 6,
+      });
+    }
 
     let errorWidget: cloudwatch.IWidget;
     if (props.errorsDisableAlerts) {
       errorWidget = new cloudwatch.GraphWidget({
-        title: `Errors/${errorsMetric.period.toMinutes()}min`,
+        title: `Errors/${this.errorsMetric.period.toMinutes()}min`,
         width: 6,
-        left: [errorsMetric],
+        left: [this.errorsMetric],
       });
     } else {
       errorWidget = new cloudwatch.AlarmWidget({
-        title: `Errors/${errorsMetric.period.toMinutes()}min`,
-        alarm: errorsAlarm,
+        title: `Errors/${this.errorsMetric.period.toMinutes()}min`,
+        alarm: this.errorsAlarm!,
         width: 6,
       });
     }
 
     this.watchful.addWidgets(
-      new cloudwatch.GraphWidget({
-        title: `Invocations/${invocationsMetric.period.toMinutes()}min`,
-        width: 6,
-        left: [invocationsMetric],
-      }),
+      invocationWidget,
       errorWidget,
       new cloudwatch.GraphWidget({
-        title: `Throttles/${throttlesMetric.period.toMinutes()}min`,
+        title: `Throttles/${this.throttlesMetric.period.toMinutes()}min`,
         width: 6,
-        left: [throttlesMetric],
-        leftAnnotations: [throttlesAlarm.toAnnotation()],
+        left: [this.throttlesMetric],
+        leftAnnotations: [this.throttlesAlarm.toAnnotation()],
       }),
       new cloudwatch.GraphWidget({
-        title: `Duration/${durationMetric.period.toMinutes()}min`,
+        title: `Duration/${this.durationMetric.period.toMinutes()}min`,
         width: 6,
-        left: [durationMetric],
-        leftAnnotations: [durationAlarm.toAnnotation()],
+        left: [this.durationMetric],
+        leftAnnotations: [this.durationAlarm.toAnnotation()],
       }),
     );
   }
 
+  createInvocationsMonitor(invocationsEnableAlerts = false, invocationsThreshold = Duration.hours(1)) {
+    const fn = this.fn;
+    this.invocationsMetric = fn.metricInvocations();
+    if (invocationsEnableAlerts) {
+      this.invocationsAlarm = this.invocationsMetric.createAlarm(this, 'InvocationAlarm', {
+        alarmDescription: `Expecting invocations to occur every ${invocationsThreshold.toHours()}hours`,
+        threshold: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        evaluationPeriods: 1,
+      });
+      this.invocationsMetric.with({ period: invocationsThreshold } );
+      this.watchful.addAlarm(this.invocationsAlarm);
+    }
+  }
+
   private createErrorsMonitor(errorsDisableAlerts = false, errorsPerMinuteThreshold = 0) {
     const fn = this.fn;
-    const errorsMetric = fn.metricErrors();
-    const errorsAlarm = errorsMetric.createAlarm(this, 'ErrorsAlarm', {
-      alarmDescription: `Over ${errorsPerMinuteThreshold} errors per minute`,
-      threshold: errorsPerMinuteThreshold,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 3,
-    });
+    this.errorsMetric = fn.metricErrors();
     if (!errorsDisableAlerts) {
-      this.watchful.addAlarm(errorsAlarm);
+      this.errorsAlarm = this.errorsMetric.createAlarm(this, 'ErrorsAlarm', {
+        alarmDescription: `Over ${errorsPerMinuteThreshold} errors per minute`,
+        threshold: errorsPerMinuteThreshold,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        evaluationPeriods: 3,
+      });
+      this.watchful.addAlarm(this.errorsAlarm);
     }
-    return { errorsMetric, errorsAlarm };
   }
 
   private createThrottlesMonitor(throttlesPerMinuteThreshold = 0) {
     const fn = this.fn;
-    const throttlesMetric = fn.metricThrottles();
-    const throttlesAlarm = throttlesMetric.createAlarm(this, 'ThrottlesAlarm', {
+    this.throttlesMetric = fn.metricThrottles();
+    this.throttlesAlarm = this.throttlesMetric.createAlarm(this, 'ThrottlesAlarm', {
       alarmDescription: `Over ${throttlesPerMinuteThreshold} throttles per minute`,
       threshold: throttlesPerMinuteThreshold,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       evaluationPeriods: 3,
     });
-    this.watchful.addAlarm(throttlesAlarm);
-    return { throttlesMetric, throttlesAlarm };
+    this.watchful.addAlarm(this.throttlesAlarm);
   }
 
   private createDurationMonitor(timeoutSec: number, durationPercentThreshold: number = DEFAULT_DURATION_THRESHOLD_PERCENT) {
     const fn = this.fn;
-    const durationMetric = fn.metricDuration();
+    this.durationMetric = fn.metricDuration();
     const durationThresholdSec = Math.floor(durationPercentThreshold / 100 * timeoutSec);
-    const durationAlarm = durationMetric.createAlarm(this, 'DurationAlarm', {
+    this.durationAlarm = this.durationMetric.createAlarm(this, 'DurationAlarm', {
       alarmDescription: `p99 latency >= ${durationThresholdSec}s (${durationPercentThreshold}%)`,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       threshold: durationThresholdSec * 1000, // milliseconds
       evaluationPeriods: 3,
     });
-    this.watchful.addAlarm(durationAlarm);
-    return { durationMetric, durationAlarm };
+    this.watchful.addAlarm(this.durationAlarm);
   }
 }
 


### PR DESCRIPTION
Optionally provide alarms on a minimum number of lambda invocations.  (Not concerned with an upper limit)
Remove the creation of alarms that aren't used.
Refactor alarms and metrics as member variables to better allow for conditional assignment and creation.