### PR TITLE
feat: updating restApi to be union of RestApi and IRestApi

### DIFF
--- a/API.md
+++ b/API.md
@@ -740,7 +740,7 @@ A list of operations to monitor separately.
 
 ##### `restApi`<sup>Required</sup> <a name="@myhelix/cdk-watchful.WatchApiGatewayProps.property.restApi"></a>
 
-- *Type:* [`@aws-cdk/aws-apigateway.RestApi`](#@aws-cdk/aws-apigateway.RestApi)
+- *Type:* [`@aws-cdk/aws-apigateway.IRestApi`](#@aws-cdk/aws-apigateway.IRestApi) | [`@aws-cdk/aws-apigateway.RestApi`](#@aws-cdk/aws-apigateway.RestApi)
 
 The API Gateway REST API that is being watched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+### [0.5.141](https://github.com/myhelix/cdk-watchful/compare/v0.5.140...v0.5.141) (2024-02-13)
 
 ### [0.5.140](https://github.com/myhelix/cdk-watchful/compare/v0.5.139...v0.5.140) (2021-04-20)
 

--- a/src/api-gateway.ts
+++ b/src/api-gateway.ts
@@ -47,7 +47,7 @@ export interface WatchApiGatewayProps extends WatchApiGatewayOptions {
   /**
    * The API Gateway REST API that is being watched.
    */
-  readonly restApi: apigw.RestApi;
+  readonly restApi: apigw.IRestApi|apigw.RestApi;
 }
 
 export class WatchApiGateway extends Construct {


### PR DESCRIPTION
## Background
Large RestAPI collections can exceed AWS's cap on 500 resources per stack. In order to support large RestAPI collections the WatchApiGateway construct may not be defined in the same stack as the RestAPI resource. In these cases the existing WatchApiGateway construct cannot watch the created API gateway because it only accepts an `apigw.RestApi` object and not `apigw.IRestApi` object.

## What
Support multistack RestAPI collections by allow restApi to be either a `apigw.RestApi` or `apigw.IRestApi` resource
