### PR TITLE
feat: DSI-392 add optional alarmId prop to WatchSqs

### DIFF
--- a/API.md
+++ b/API.md
@@ -2684,6 +2684,27 @@ import { WatchSqsOptions } from '@myhelix/cdk-watchful'
 const watchSqsOptions: WatchSqsOptions = { ... }
 ```
 
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@myhelix/cdk-watchful.WatchSqsOptions.property.alarmId">alarmId</a></code> | <code>string</code> | Construct id for the CloudWatch alarm. |
+
+---
+
+##### `alarmId`<sup>Optional</sup> <a name="alarmId" id="@myhelix/cdk-watchful.WatchSqsOptions.property.alarmId"></a>
+
+```typescript
+public readonly alarmId: string;
+```
+
+- *Type:* string
+
+Construct id for the CloudWatch alarm.
+
+@default 'deliveryToRedshiftAlarm' (preserves existing alarm identity; pass a descriptive id for new callers)
+
+---
 
 ### WatchSqsServiceProps <a name="WatchSqsServiceProps" id="@myhelix/cdk-watchful.WatchSqsServiceProps"></a>
 
@@ -2699,9 +2720,24 @@ const watchSqsServiceProps: WatchSqsServiceProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#@myhelix/cdk-watchful.WatchSqsServiceProps.property.alarmId">alarmId</a></code> | <code>string</code> | Construct id for the CloudWatch alarm. |
 | <code><a href="#@myhelix/cdk-watchful.WatchSqsServiceProps.property.sqs">sqs</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | *No description.* |
 | <code><a href="#@myhelix/cdk-watchful.WatchSqsServiceProps.property.title">title</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@myhelix/cdk-watchful.WatchSqsServiceProps.property.watchful">watchful</a></code> | <code><a href="#@myhelix/cdk-watchful.IWatchful">IWatchful</a></code> | *No description.* |
+
+---
+
+##### `alarmId`<sup>Optional</sup> <a name="alarmId" id="@myhelix/cdk-watchful.WatchSqsServiceProps.property.alarmId"></a>
+
+```typescript
+public readonly alarmId: string;
+```
+
+- *Type:* string
+
+Construct id for the CloudWatch alarm.
+
+@default 'deliveryToRedshiftAlarm' (preserves existing alarm identity; pass a descriptive id for new callers)
 
 ---
 

--- a/src/sqs.ts
+++ b/src/sqs.ts
@@ -5,6 +5,8 @@ import { Construct } from 'constructs';
 import { IWatchful } from './api';
 
 export interface WatchSqsOptions {
+  /** Construct id for the CloudWatch alarm. @default 'deliveryToRedshiftAlarm' (preserves existing alarm identity; pass a descriptive id for new callers) */
+  readonly alarmId?: string;
 }
 
 export interface WatchSqsServiceProps extends WatchSqsOptions {
@@ -13,9 +15,12 @@ export interface WatchSqsServiceProps extends WatchSqsOptions {
   readonly sqs: sqs.IQueue;
 }
 
+const DEFAULT_ALARM_ID = 'deliveryToRedshiftAlarm';
+
 export class WatchSqsService extends Construct {
   private readonly watchful: IWatchful;
   private readonly sqs: sqs.IQueue;
+  private readonly alarmId: string;
 
   private messageMetric!: cloudwatch.Metric;
   private messageAlarm!: cloudwatch.Alarm;
@@ -25,6 +30,7 @@ export class WatchSqsService extends Construct {
 
     this.watchful = props.watchful;
     this.sqs = props.sqs;
+    this.alarmId = props.alarmId ?? DEFAULT_ALARM_ID;
 
     this.watchful.addSection(props.title, {
       links: [{ title: 'SQS Console', url: linkForSqsService(this.sqs) }],
@@ -53,7 +59,7 @@ export class WatchSqsService extends Construct {
         QueueName: this.sqs.queueName,
       },
     });
-    this.messageAlarm = new cloudwatch.Alarm(this, 'deliveryToRedshiftAlarm', {
+    this.messageAlarm = new cloudwatch.Alarm(this, this.alarmId, {
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       metric: this.messageMetric,
       threshold: 0, // TODO pass parameter.  Used for DLQs only right now

--- a/test/sqs.test.ts
+++ b/test/sqs.test.ts
@@ -1,0 +1,31 @@
+import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import { Watchful } from '../src';
+
+function alarmLogicalIds(stack: Stack): string[] {
+  return Object.keys(Template.fromStack(stack).findResources('AWS::CloudWatch::Alarm'));
+}
+
+test('watchSqs defaults alarmId to deliveryToRedshiftAlarm for backwards compatibility', () => {
+  const stack = new Stack();
+  const wf = new Watchful(stack, 'watchful');
+  const queue = new Queue(stack, 'Q');
+
+  wf.watchSqs('my-queue', queue);
+
+  const ids = alarmLogicalIds(stack);
+  expect(ids.some(id => id.includes('deliveryToRedshiftAlarm'))).toBe(true);
+});
+
+test('watchSqs respects caller-supplied alarmId', () => {
+  const stack = new Stack();
+  const wf = new Watchful(stack, 'watchful');
+  const queue = new Queue(stack, 'Q');
+
+  wf.watchSqs('my-queue', queue, { alarmId: 'MyCustomDlqAlarm' });
+
+  const ids = alarmLogicalIds(stack);
+  expect(ids.some(id => id.includes('MyCustomDlqAlarm'))).toBe(true);
+  expect(ids.some(id => id.includes('deliveryToRedshiftAlarm'))).toBe(false);
+});


### PR DESCRIPTION
## Summary
- Adds optional `alarmId` prop to `WatchSqsOptions` so callers can supply a descriptive construct id for the SQS visibility alarm (e.g. `PublishHrnIDDlqMessagesAlarm`) instead of inheriting the hardcoded `deliveryToRedshiftAlarm`.
- Default preserves the existing id so current consumers see **no change on upgrade** — alarm CloudFormation logical ID stays stable, no replacement on next deploy.
- Service owners opt in per queue by passing a meaningful `alarmId` when they are ready (same model as picking up CDK version bumps).

## Why the default stays `deliveryToRedshiftAlarm`
Every existing service using `wf.watchSqs(...)` today has an alarm whose CFN logical ID contains `deliveryToRedshiftAlarm`. Changing the default would trigger alarm replacement across every service on its next deploy — not the behavior we want. The ugly default is intentional backwards-compat and is documented in the JSDoc.

## Test plan
- [x] `watchSqs defaults alarmId to deliveryToRedshiftAlarm for backwards compatibility` — asserts no-op default behavior
- [x] `watchSqs respects caller-supplied alarmId` — asserts the new opt-in path
- [ ] Reviewer: confirm existing consumer stacks synth identically (same alarm logical IDs) with this library version vs `release-v2@d3bc2aa`

## Follow-ups (not this PR)
- Update service template repo to pass a meaningful `alarmId` in its stock `watchSqs` call so new services get descriptive names from day 1.
- Individual service owners opt into `alarmId` on their own cadence.

[DSI-392](https://helix.atlassian.net/browse/DSI-392)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DSI-392]: https://myhelix.atlassian.net/browse/DSI-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ