### PR TITLE
feat: anchor release line to v2.x

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -178,7 +178,8 @@
       "name": "release:release-v2",
       "description": "Prepare a release from \"release-v2\" branch",
       "env": {
-        "RELEASE": "true"
+        "RELEASE": "true",
+        "MAJOR": "2"
       },
       "steps": [
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -18,6 +18,11 @@ const project = new awscdk.AwsCdkConstructLibrary({
   cdkVersion,
   cdkVersionPinning: true,
 
+  // Anchor release line to v2.x. The bump task filters tags by "v2.*" and
+  // refuses to publish a non-v2 version. v2.29.0 was pre-tagged on this
+  // branch so standard-version minor-bumps to v2.30.0 on the next release.
+  majorVersion: 2,
+
   devDeps: ['aws-sdk', '@aws-cdk/assert'],
 });
 


### PR DESCRIPTION
## Summary

Add `majorVersion: 2` to `.projenrc.js` so projen's bump task constrains releases to `v2.x`. Combined with the pre-pushed `v2.29.0` anchor tag on `release-v2` HEAD, standard-version will minor-bump to `v2.30.0` on merge of this PR.

## Why

- npm `latest` for `@myhelix/cdk-watchful` points at a stale `2.29.0` published years ago from an abandoned branch.
- Active development on `release-v2` has been releasing as `0.5.x` (currently `0.5.205`), which sorts *below* the orphan `2.29.0` and confuses consumers — they pin `^2.29.0` and silently miss the active line.
- After this lands, the active line becomes `2.30.0+`, `latest` moves forward, and consumers can pin `^2.30.0` with normal semver intuition.

## What this PR changes

```
.projenrc.js      | +5 lines (majorVersion: 2 + comment)
.projen/tasks.json| +1 line  (MAJOR=2 env var, auto-regenerated by projen)
```

That's it — surgical change.

## How the next release will work

On merge:
1. Push to `release-v2` triggers the `release` workflow.
2. Bump task reads `MAJOR=2`, filters git tags to `v2.*`, finds `v2.29.0` (pre-pushed earlier today on commit `6ee1cba`).
3. standard-version conventional-commit minor-bumps `2.29.0` → `2.30.0`.
4. Workflow publishes `2.30.0` to npmjs.org and updates `latest` dist-tag (projen default `npmDistTag: "latest"`).

After this lands, `0.5.x` releases are physically blocked — projen's bump task throws if standard-version produces a non-`v2.x` version.

## Risk

Low.

- No code change in the library itself. Just release-pipeline config.
- Confirmed across 32 myhelix consumer repos: all use the `cdk/install` CircleCI orb which defaults to `--frozen-lockfile: true` plus committed `yarn.lock`. None will silently float to `2.30.0` — every consumer opts in explicitly.
- `template-fargate-service` lacks a lockfile but pins exact `2.29.0` so the resolver can't pick `2.30.0`.

## Test plan

- [x] `npx projen` regenerates only `.projen/tasks.json` (no other drift)
- [x] Diff is minimal — `majorVersion: 2` and the implied `MAJOR=2` env var
- [ ] On merge, release workflow publishes `2.30.0` to npm
- [ ] `npm view @myhelix/cdk-watchful dist-tags` shows `latest: 2.30.0`

Related: [DSI-392](https://myhelix.atlassian.net/browse/DSI-392), heart2#79

[DSI-392]: https://myhelix.atlassian.net/browse/DSI-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ